### PR TITLE
Allow customization of host binding in local_serve.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ zedex serve
 # Alternatively to use zedex as a proxy
 zedex serve --proxy-mode
 
+# Start a local server on a custom host and port
+zedex serve --host 0.0.0.0 --port 8080
+
 # Download a specific extension
 zedex get extension extension-id-here
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ zedex get extension extension-id-here
 # Fetch the extension index
 zedex get extension-index
 
+# Get the latest release for the autoupdate check when you launch zed
+zedex release latest
+
 # Show available commands and options
 zedex --help
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To configure Zed to use your local server, add this to your Zed config:
 
 ```json
 {
-  "extension_server": "http://localhost:2654"
+  "server_url": "http://127.0.0.1:2654"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ As such I made this over the weekend. A lot of the heavy lifting was made by Pra
 zedex get all-extensions
 
 # Start a local server on the default port (2654)
-zedex serve --local-mode
+zedex serve
+
+# Alternatively to use zedex as a proxy
+zedex serve --proxy-mode
 
 # Download a specific extension
 zedex get extension extension-id-here

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,10 @@ enum Commands {
         /// Port to run the server on
         #[clap(long, default_value = "2654")] // If you're reading this, you're a nerd. And yes it's ZED. Z=26 E=5 D=4
         port: u16,
+
+        /// Host IP address to bind the server to
+        #[clap(long, default_value = "127.0.0.1")]
+        host: String,
         
         /// Directory containing extension archives and metadata
         #[clap(long)]
@@ -514,7 +518,7 @@ async fn main() -> Result<()> {
                 }
             },
         },
-        Commands::Serve { port, extensions_dir, releases_dir, proxy_mode } => {
+        Commands::Serve { port, host, extensions_dir, releases_dir, proxy_mode } => {
             // Resolve directories from root_dir if not provided
             let extensions_dir = extensions_dir.unwrap_or_else(|| root_dir.clone());
             let releases_dir = releases_dir.or_else(|| Some(root_dir.join("releases")));
@@ -522,6 +526,7 @@ async fn main() -> Result<()> {
             // Create and configure the local server
             let config = zed::ServerConfig {
                 port,
+                host,
                 extensions_dir,
                 releases_dir,
                 proxy_mode,

--- a/src/zed/local_server.rs
+++ b/src/zed/local_server.rs
@@ -11,6 +11,7 @@ use crate::zed::{WrappedExtensions, Version, extensions_utils};
 #[derive(Clone)]
 pub struct ServerConfig {
     pub port: u16,
+    pub host: String,
     pub extensions_dir: PathBuf,
     pub releases_dir: Option<PathBuf>,
     pub proxy_mode: bool,
@@ -21,6 +22,7 @@ impl Default for ServerConfig {
         let root_dir = PathBuf::from(".zedex-cache");
         Self {
             port: 2654,
+            host: "127.0.0.1".to_string(),
             extensions_dir: root_dir.clone(),
             releases_dir: Some(root_dir.join("releases")),
             proxy_mode: false,
@@ -43,7 +45,7 @@ impl LocalServer {
             config: config.clone(),
         });
 
-        info!("Starting local Zed extension server on port {}", config.port);
+        info!("Starting local Zed extension server on {}:{}", config.host, config.port);
         info!("Serving extensions from {:?}", config.extensions_dir);
         if let Some(releases_dir) = &config.releases_dir {
             info!("Serving releases from {:?}", releases_dir);
@@ -94,7 +96,7 @@ impl LocalServer {
             
             app
         })
-        .bind(("127.0.0.1", config.port))?
+        .bind((config.host.as_str(), config.port))?
         .run()
         .await?;
 
@@ -356,4 +358,4 @@ async fn proxy_api_request(
             HttpResponse::InternalServerError().body(format!("Error proxying request: {}", e))
         }
     }
-} 
+}


### PR DESCRIPTION
Fixes #4

Add customization of host binding in local_serve.rs

* Add a new argument `--host` to the `Serve` command in `src/main.rs` to specify the host IP address.
* Update the `Serve` command in `src/main.rs` to pass the `host` argument to the `ServerConfig` struct.
* Add a new field `host` to the `ServerConfig` struct in `src/zed/local_server.rs` to store the host IP address.
* Update the `HttpServer::bind` method in `src/zed/local_server.rs` to use the `host` field from `ServerConfig` to bind to the specified IP address.
* Update the `README.md` file to include documentation on how to use the `--host` argument with the `serve` command.

