### PR TITLE
Optimize CI build to only trigger on relevant file changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,16 @@ on:
     branches: [ main ]
     tags:
       - 'v*'
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'src/**'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'src/**'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Fixes #11

Update GitHub Actions workflow to build `zedex` only when relevant files change

* Add `paths` filter to `push` event to include `Cargo.toml`, `Cargo.lock`, and files in the `/src` directory
* Add `paths` filter to `pull_request` event to include `Cargo.toml`, `Cargo.lock`, and files in the `/src` directory

